### PR TITLE
Fixversuch #1 - HttpMessageNotReadableException fangen

### DIFF
--- a/src/main/java/de/szut/lf8_project/controller/ProjectController.java
+++ b/src/main/java/de/szut/lf8_project/controller/ProjectController.java
@@ -14,6 +14,8 @@ import de.szut.lf8_project.domain.adapter.OpenApiProjectController;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.WebRequest;
@@ -49,7 +51,7 @@ public class ProjectController implements OpenApiProjectController {
     }
 
     @ExceptionHandler
-    public ResponseEntity<ProblemDetails> serializeInvalidParamsException(MethodArgumentNotValidException ex, WebRequest request) {
+    public ResponseEntity<ProblemDetails> serializeInvalidParamsException(BindException ex, WebRequest request) {
         Map<String, String> errorMap = new HashMap<>();
         ex.getBindingResult().getFieldErrors().forEach(error -> {
             errorMap.put(error.getField(), error.getDefaultMessage());
@@ -62,6 +64,16 @@ public class ProjectController implements OpenApiProjectController {
                                 msg.isBlank() ?
                                         "Your request contains invalid parameter. Please check if your field types are correct" :
                                         msg)
+                )),
+                Errorcode.INVALID_REQUEST_PARAMETER.getHttpRepresentation());
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ProblemDetails> serializeNotReadableException(HttpMessageNotReadableException ex) {
+        return new ResponseEntity<>(
+                ProblemDetails.fromErrorDetail(new ErrorDetail(
+                        Errorcode.INVALID_REQUEST_PARAMETER,
+                        new FailureMessage("Your request could not be read or parsed" )
                 )),
                 Errorcode.INVALID_REQUEST_PARAMETER.getHttpRepresentation());
     }


### PR DESCRIPTION
Fixt, dass ein der Test, der CreateProject auf 400er prüft stattdessen mit 500 failed.

Tritt irgendwie nur in der Pipeline und nicht lokal

`2022-11-09 09:58:54.920  WARN 1726 --- [           main] .w.s.m.s.DefaultHandlerExceptionResolver : Resolved [org.springframework.http.converter.HttpMessageNotReadableException: JSON parse error: Unrecognized token 'notAnId': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false'); nested exception is com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'notAnId': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
 at [Source: (PushbackInputStream); line: 3, column: 34]]`